### PR TITLE
fix(linux): set executable permissions for Java runtime binaries

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group 'fr.arinonia'
-version '1.0-SNAPSHOT'
+version '1.0.1'
 
 repositories {
     mavenCentral()

--- a/src/main/java/fr/arinonia/bootstrap/config/BootstrapConfig.java
+++ b/src/main/java/fr/arinonia/bootstrap/config/BootstrapConfig.java
@@ -11,7 +11,7 @@ public class BootstrapConfig {
 
     // Application
     private final String appName = "AltisCore Bootstrap";
-    private final String appVersion = "1.0.0";
+    private final String appVersion = "1.0.1";
     private final String discordUrl = "https://discord.gg/your-discord";
 
     // Runtime

--- a/src/main/java/fr/arinonia/bootstrap/utils/OSDetector.java
+++ b/src/main/java/fr/arinonia/bootstrap/utils/OSDetector.java
@@ -62,4 +62,13 @@ public class OSDetector {
             return false;
         }
     }
+
+    /**
+     * Check if the current system is a Unix system
+     * @return true if the current system is a Unix system
+     */
+    public static boolean isUnixSystem() {
+        final String os = System.getProperty("os.name").toLowerCase();
+        return os.contains("nix") || os.contains("nux") || os.contains("aix");
+    }
 }


### PR DESCRIPTION
This commit fixes the Linux permission issue where Java runtime binaries were not executable after extraction, requiring manual chmod intervention.

- Add automatic permission setting for runtime binaries
- Handle permission setting for all required executables in bin/
- Only apply changes on Unix-like systems